### PR TITLE
Remove available attributes for Mac Catalyst

### DIFF
--- a/Sources/Control/AsyncButton.swift
+++ b/Sources/Control/AsyncButton.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 /// A control that initiates an action.
 /// - SeeAlso: [`SwiftUI.Button`](https://developer.apple.com/documentation/swiftui/button)
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 public struct AsyncButton<Label: View>: AsyncControl {
     public typealias Base = Button<Label>
     package typealias Value = ()
@@ -43,7 +43,7 @@ public struct AsyncButton<Label: View>: AsyncControl {
     }
 }
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 extension AsyncButton {
     /// Creates a button that displays a custom label.
     ///
@@ -66,7 +66,7 @@ extension AsyncButton {
     }
 }
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 extension AsyncButton where Label == Text {
     /// Creates a button that generates its label from a localized string key.
     /// - Parameters:
@@ -108,7 +108,7 @@ extension AsyncButton where Label == Text {
     }
 }
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 extension AsyncButton where Label == SwiftUI.Label<Text, Image> {
     /// Creates a button that generates its label from a localized string key and system image name.
     /// - Parameters:
@@ -154,7 +154,7 @@ extension AsyncButton where Label == SwiftUI.Label<Text, Image> {
     }
 }
 
-@available(iOS 17.0, macOS 14.0, macCatalyst 17.0, tvOS 17.0, watchOS 10.0, visionOS 1.0, *)
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 1.0, *)
 extension AsyncButton where Label == SwiftUI.Label<Text, Image> {
     /// Creates a button that generates its label from a localized string key and image resource.
     /// - Parameters:
@@ -200,7 +200,7 @@ extension AsyncButton where Label == SwiftUI.Label<Text, Image> {
     }
 }
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 extension AsyncButton {
     /// Creates a button with a specified role that displays a custom label.
     /// - Parameters:
@@ -224,7 +224,7 @@ extension AsyncButton {
     }
 }
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 extension AsyncButton where Label == Text {
     /// Creates a button with a specified role that generates its label from a localized string key.
     /// - Parameters:
@@ -270,7 +270,7 @@ extension AsyncButton where Label == Text {
     }
 }
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 extension AsyncButton where Label == SwiftUI.Label<Text, Image> {
     /// Creates a button with a specified role that generates its label from a localized string key and a system image.
     /// - Parameters:
@@ -320,7 +320,7 @@ extension AsyncButton where Label == SwiftUI.Label<Text, Image> {
     }
 }
 
-@available(iOS 17.0, macOS 14.0, macCatalyst 17.0, tvOS 17.0, watchOS 10.0, visionOS 1.0, *)
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 1.0, *)
 extension AsyncButton where Label == SwiftUI.Label<Text, Image> {
     /// Creates a button with a specified role that generates its label from a localized string key and an image resource.
     /// - Parameters:

--- a/Sources/Control/AsyncTextFieldLink.swift
+++ b/Sources/Control/AsyncTextFieldLink.swift
@@ -12,7 +12,6 @@ import SwiftUI
 @available(watchOS 9.0, *)
 @available(iOS, unavailable)
 @available(macOS, unavailable)
-@available(macCatalyst, unavailable)
 @available(tvOS, unavailable)
 @available(visionOS, unavailable)
 public struct AsyncTextFieldLink<Label: View>: AsyncControl {
@@ -50,7 +49,6 @@ public struct AsyncTextFieldLink<Label: View>: AsyncControl {
 @available(watchOS 9.0, *)
 @available(iOS, unavailable)
 @available(macOS, unavailable)
-@available(macCatalyst, unavailable)
 @available(tvOS, unavailable)
 @available(visionOS, unavailable)
 extension AsyncTextFieldLink {
@@ -80,7 +78,6 @@ extension AsyncTextFieldLink {
 @available(watchOS 9.0, *)
 @available(iOS, unavailable)
 @available(macOS, unavailable)
-@available(macCatalyst, unavailable)
 @available(tvOS, unavailable)
 @available(visionOS, unavailable)
 extension AsyncTextFieldLink where Label == Text {

--- a/Sources/Core/AsyncControl.swift
+++ b/Sources/Core/AsyncControl.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 package protocol AsyncControl: View {
     associatedtype Base: View
     associatedtype Value

--- a/Sources/Core/AsyncControlView.swift
+++ b/Sources/Core/AsyncControlView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 package struct AsyncControlView<Base: View, Value>: View {
     private let priority: TaskPriority
     private let action: @Sendable (_ value: Value) async -> Void

--- a/Sources/Core/_AsyncControlTrigger.swift
+++ b/Sources/Core/_AsyncControlTrigger.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// - Warning: This `Equatable` compliance is a dummy implementation added for use in `SwiftUI.View.onPreferenceChange(_:perform:)`.
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 package struct _AsyncControlTrigger<Value>: Equatable {
     private let action: (_ value: Value) -> Void
     

--- a/Sources/Core/_AsyncControlTriggerPreferenceKey.swift
+++ b/Sources/Core/_AsyncControlTriggerPreferenceKey.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
 package struct _AsyncControlTriggerPreferenceKey<Value>: PreferenceKey {
     package static var defaultValue: _AsyncControlTrigger<Value> { fatalError("This property is not expected to be called.") }
     package static func reduce(value: inout _AsyncControlTrigger<Value>, nextValue: () -> _AsyncControlTrigger<Value>) { fatalError("This function is not expected to be called.") }


### PR DESCRIPTION
If available attributes for Mac Catalyst remain, a compile error will occur.

- Xcode 15.0.1 (15A507)
- `swift --version`
  - `swift-driver version: 1.87.1 Apple Swift version 5.9 (swiftlang-5.9.0.128.108 clang-1500.0.40.1) Target: arm64-apple-macosx14.0`
- `swift package --version`
  - `Swift Package Manager - Swift 5.9.0`

|Before|After|
|:-:|:-:|
|![](https://github.com/treastrain/AsyncSwiftUI/assets/13805382/a8f9d734-2589-47ca-9ad4-286b003648b3)|![](https://github.com/treastrain/AsyncSwiftUI/assets/13805382/d4ea3972-df0f-45c5-80e1-ce41a0ba3196)|